### PR TITLE
fix: decouple dynamic cubemap conversion from GGX setting

### DIFF
--- a/src/Features/VanillaFresnel.cpp
+++ b/src/Features/VanillaFresnel.cpp
@@ -110,12 +110,7 @@ void VanillaFresnel::DrawSettings()
 	ImGui::Checkbox("Enable Vanilla Fresnel", reinterpret_cast<bool*>(&settings.Enable));
 	ImGui::Checkbox("Enable Phong to GGX", reinterpret_cast<bool*>(&settings.EnableGGX));
 	ImGui::Checkbox("Enable Phong to GGX on Grass", reinterpret_cast<bool*>(&settings.EnableGGXOnGrass));
-	if (!settings.EnableGGX) {
-		settings.EnableDynamicCubemapsConversion = false;
-	}
-	ImGui::BeginDisabled(!settings.EnableGGX);
 	ImGui::Checkbox("Enable Auto Cubemaps Conversion", reinterpret_cast<bool*>(&settings.EnableDynamicCubemapsConversion));
-	ImGui::EndDisabled();
 	ImGui::Checkbox("Enable Eye Special Handling", reinterpret_cast<bool*>(&settings.EnableEyeSpecialHandling));
 
 	ImGui::SliderFloat("Roughness Multiplier", &settings.RoughnessMultiplier, 0.0f, 10.0f, "%.2f");


### PR DESCRIPTION
## What

`VanillaFresnel::DrawSettings()` force-clears `EnableDynamicCubemapsConversion` and disables its checkbox whenever `EnableGGX` is off:

```cpp
if (!settings.EnableGGX) {
    settings.EnableDynamicCubemapsConversion = false;
}
ImGui::BeginDisabled(!settings.EnableGGX);
ImGui::Checkbox("Enable Auto Cubemaps Conversion", reinterpret_cast<bool*>(&settings.EnableDynamicCubemapsConversion));
ImGui::EndDisabled();
```

But `Lighting.hlsl` checks `EnableDynamicCubemapsConversion` independently of `EnableGGX` in every gate:

- `vfStartDynamicCubemapTest = (enableVanillaFresnel && SharedData::vanillaFresnelSettings.EnableDynamicCubemapsConversion);`
- `dynamicCubemap = dynamicCubemap || (SharedData::vanillaFresnelSettings.EnableDynamicCubemapsConversion && enableVanillaFresnel);`
- `if (!(enableVanillaFresnel && SharedData::vanillaFresnelSettings.EnableDynamicCubemapsConversion))`

`EnableGGX` is gated separately, only for the complex-material specular multiply (`if (!(enableVanillaFresnel && SharedData::vanillaFresnelSettings.EnableGGX)) specularColor *= complexSpecular;`).

So dynamic cubemap conversion is a fully independent, working shader option, but the UI makes it unreachable unless GGX is also enabled.

## Fix

Removed the forced clear + `BeginDisabled`/`EndDisabled` wrapper so the two settings toggle independently, matching their actual independence in the shader.

## Testing

Small, surgical UI-only change (5 lines removed, one file) — no shader or settings-struct changes, so it's inert unless a user actually flips "Auto Cubemaps Conversion" on without GGX, which is exactly the previously-blocked case.

(Found while reviewing this feature for integration into a downstream fork — happy to adjust if there's context I'm missing on why the coupling was intentional.)